### PR TITLE
fix the bug: kube-batchd can not aware of the changes of gpu resources when scale up cluster. 

### DIFF
--- a/pkg/batchd/cache/node_info.go
+++ b/pkg/batchd/cache/node_info.go
@@ -100,6 +100,7 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 
 	ni.Name = node.Name
 	ni.Node = node
+	ni.Idle = NewResource(node.Status.Allocatable)
 	ni.Allocatable = NewResource(node.Status.Allocatable)
 	ni.Capability = NewResource(node.Status.Capacity)
 }

--- a/pkg/batchd/cache/node_info.go
+++ b/pkg/batchd/cache/node_info.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"k8s.io/api/core/v1"
+	"reflect"		
 )
 
 // NodeInfo is node level aggregated information.
@@ -100,9 +101,23 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 
 	ni.Name = node.Name
 	ni.Node = node
-	ni.Idle = NewResource(node.Status.Allocatable)
 	ni.Allocatable = NewResource(node.Status.Allocatable)
 	ni.Capability = NewResource(node.Status.Capacity)
+}
+
+func (ni *NodeInfo) UpdateNode(oldNode, newNode *v1.Node) {
+	if !reflect.DeepEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable) {
+		ni.Idle = NewResource(newNode.Status.Allocatable)
+		ni.Allocatable = NewResource(newNode.Status.Allocatable)
+
+		for _, p := range ni.Pods {
+			ni.Idle.Sub(p.Request)
+			ni.Used.Add(p.Request)
+		}
+	}
+	ni.Name = newNode.Name
+	ni.Node = newNode
+	ni.Capability = NewResource(newNode.Status.Capacity)
 }
 
 func (ni *NodeInfo) AddPod(p *PodInfo) {


### PR DESCRIPTION
fix the issue: [kube-batchd can not aware of the changes of gpu resources when scale up cluster. ](https://github.com/kubernetes-incubator/kube-arbitrator/issues/302)